### PR TITLE
Make left_joins an alias for left_join

### DIFF
--- a/lib/left_join/adapters/active_record_adapter.rb
+++ b/lib/left_join/adapters/active_record_adapter.rb
@@ -21,6 +21,8 @@ module LeftJoin
           end
         end
       end
+
+      alias_method :left_joins, :left_join
     end
 
     if defined?(ActiveRecord)

--- a/spec/left_join_spec.rb
+++ b/spec/left_join_spec.rb
@@ -25,6 +25,12 @@ describe 'LeftJoin' do
       "\"categories\".\"id\" = \"books\".\"category_id\"")
   end
 
+  it 'aliases left_join as left_joins' do
+    expect(Book.left_joins(:category).to_sql).to eq(
+      "SELECT \"books\".* FROM \"books\" LEFT OUTER JOIN \"categories\" ON "\
+      "\"categories\".\"id\" = \"books\".\"category_id\"")
+  end
+
   it 'works with nested associations' do
     expect(Category.left_join(books: :author).to_sql).to eq(
       "SELECT \"categories\".* FROM \"categories\" "\


### PR DESCRIPTION
This makes it more consistent with ActiveRecord's existing "joins" method